### PR TITLE
removed FSA check, which was causing the promise to not resolve when …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,9 @@
-import { isFSA } from 'flux-standard-action';
-
 function isPromise(val) {
   return val && typeof val.then === 'function';
 }
 
 export default function promiseMiddleware({ dispatch }) {
   return next => action => {
-    if (!isFSA(action)) {
-      return isPromise(action)
-        ? action.then(dispatch)
-        : next(action);
-    }
-
     return isPromise(action.payload)
       ? action.payload.then(
           result => dispatch({ ...action, payload: result }),


### PR DESCRIPTION
…more than 2 (type, payload) properties were passed from an action to a reducer.
