### PR TITLE
--save no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [FSA](https://github.com/redux-utilities/flux-standard-action)-compliant promise [middleware](https://redux.js.org/advanced/middleware) for Redux.
 
 ```js
-npm install --save redux-promise
+npm install redux-promise
 ```
 
 ## Usage


### PR DESCRIPTION
`--save` is on by default as of [npm 5](https://blog.npmjs.org/post/161081169345/v500), so `npm install aphrodite` is functionally equivalent to `npm install --save aphrodite` now